### PR TITLE
Allow cycling through OSC visibility mode

### DIFF
--- a/mordenx.lua
+++ b/mordenx.lua
@@ -2223,6 +2223,7 @@ function visibility_mode(mode, no_osd)
     end
 
 	user_opts.visibility = mode
+    utils.shared_script_property_set("osc-visibility", mode)
 
     if not no_osd and tonumber(mp.get_property('osd-level')) >= 1 then
         mp.osd_message('OSC visibility: ' .. mode)

--- a/mordenx.lua
+++ b/mordenx.lua
@@ -2199,6 +2199,16 @@ end
 -- mode can be auto/always/never/cycle
 -- the modes only affect internal variables and not stored on its own.
 function visibility_mode(mode, no_osd)
+    if mode == "cycle" then
+        if not state.enabled then
+            mode = "auto"
+        elseif user_opts.visibility ~= "always" then
+            mode = "always"
+        else
+            mode = "never"
+        end
+    end
+
     if mode == 'auto' then
         always_on(false)
         enable_osc(true)
@@ -2211,9 +2221,9 @@ function visibility_mode(mode, no_osd)
         msg.warn('Ignoring unknown visibility mode \"' .. mode .. '\"')
         return
     end
-    
+
 	user_opts.visibility = mode
-	
+
     if not no_osd and tonumber(mp.get_property('osd-level')) >= 1 then
         mp.osd_message('OSC visibility: ' .. mode)
     end


### PR DESCRIPTION
mpv sets the <kbd>DEL</kbd> key as the default keybinding to toggle the OSC. This never took effect because `visibility_mode()` doesn't understand/accept "cycle" as its parameter. This patch fixes the issue and allows cycling the OSC visibility between `never`, `auto` and `always`. This was available in `osc.lua`, but for some reason removed in `mordenx.lua`.
Fixes one of the issues mentioned in #6.

The 2nd commit, "Expose `osc-visibility` via shared-script-properties" allows scripts to tell what the current state of the OSC is. This was added in mpv-player/mpv@d2dd4ca.