### PR TITLE
Add thumbfast integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ border = no # Optional, but recommended
 
 edit osc.conf in "\~\~/script-opts/" folder, however many options are changed, so refer to the user_opts variable in the script file for details.
 
+# Thumbnails
+
+To enable thumbnails in timeline, install [thumbfast](https://github.com/po5/thumbfast). No other step necessary.
+
 # Buttons
 
 like the built-in script, some buttons may accept multiple mouse actions, here is a list:

--- a/mordenx.lua
+++ b/mordenx.lua
@@ -194,7 +194,8 @@ local state = {
 local thumbfast = {
     width = 0,
     height = 0,
-    disabled = false
+    disabled = true,
+    available = false
 }
 
 local window_control_box_width = 138
@@ -792,18 +793,19 @@ function render_elements(master_ass)
                     elem_ass:append(tooltiplabel)
                     
                     -- thumbnail
-                    if not thumbfast.disabled and thumbfast.width ~= 0 and thumbfast.height ~= 0 then
-                        local osd_w = mp.get_property_number("osd-dimensions/w")
+                    if not thumbfast.disabled then
+                        local osd_w = mp.get_property_number("osd-width")
                         if osd_w then
                             local r_w, r_h = get_virt_scale_factor()
 
+                            local tooltip_font_size = 18
                             local thumbPad = 4
                             local thumbMarginX = 18 / r_w
-                            local thumbMarginY = 70
+                            local thumbMarginY = tooltip_font_size + thumbPad + 2 / r_h
                             local tooltipBgColor = "FFFFFF"
                             local tooltipBgAlpha = 80
                             local thumbX = math.min(osd_w - thumbfast.width - thumbMarginX, math.max(thumbMarginX, tx / r_w - thumbfast.width / 2))
-                            local thumbY = ((ty - thumbMarginY) / r_h - thumbfast.height)
+                            local thumbY = (ty - thumbMarginY) / r_h - thumbfast.height
 
                             elem_ass:new_event()
                             elem_ass:pos(thumbX * r_w, ty - thumbMarginY - thumbfast.height * r_h)
@@ -820,7 +822,7 @@ function render_elements(master_ass)
                         end
                     end
                 else
-                    if thumbfast.width ~= 0 and thumbfast.height ~= 0 then
+                    if thumbfast.available then
                         mp.commandv("script-message-to", "thumbfast", "clear")
                     end
                 end

--- a/mordenx.lua
+++ b/mordenx.lua
@@ -807,7 +807,7 @@ function render_elements(master_ass)
 
                             elem_ass:new_event()
                             elem_ass:pos(thumbX * r_w, ty - thumbMarginY - thumbfast.height * r_h)
-                            elem_ass:append(("{\\bord0\\1c&H%s&\\1a&H%X&}"):format(tooltipBgColor, tooltipBgAlpha))
+                            elem_ass:append(osc_styles.Tooltip)
                             elem_ass:draw_start()
                             elem_ass:rect_cw(-thumbPad * r_h, -thumbPad * r_h, (thumbfast.width + thumbPad) * r_w, (thumbfast.height + thumbPad) * r_h)
                             elem_ass:draw_stop()

--- a/mordenx.lua
+++ b/mordenx.lua
@@ -191,6 +191,12 @@ local state = {
     chapter_list = {},                      -- sorted by time
 }
 
+local thumbfast = {
+    width = 0,
+    height = 0,
+    disabled = false
+}
+
 local window_control_box_width = 138
 local tick_delay = 0.03
 
@@ -784,6 +790,39 @@ function render_elements(master_ass)
                     elem_ass:append(slider_lo.tooltip_style)
                     ass_append_alpha(elem_ass, slider_lo.alpha, 0)
                     elem_ass:append(tooltiplabel)
+                    
+                    -- thumbnail
+                    if not thumbfast.disabled and thumbfast.width ~= 0 and thumbfast.height ~= 0 then
+                        local osd_w = mp.get_property_number("osd-dimensions/w")
+                        if osd_w then
+                            local r_w, r_h = get_virt_scale_factor()
+
+                            local thumbPad = 4
+                            local thumbMarginX = 18 / r_w
+                            local thumbMarginY = 70
+                            local tooltipBgColor = "FFFFFF"
+                            local tooltipBgAlpha = 80
+                            local thumbX = math.min(osd_w - thumbfast.width - thumbMarginX, math.max(thumbMarginX, tx / r_w - thumbfast.width / 2))
+                            local thumbY = ((ty - thumbMarginY) / r_h - thumbfast.height)
+
+                            elem_ass:new_event()
+                            elem_ass:pos(thumbX * r_w, ty - thumbMarginY - thumbfast.height * r_h)
+                            elem_ass:append(("{\\bord0\\1c&H%s&\\1a&H%X&}"):format(tooltipBgColor, tooltipBgAlpha))
+                            elem_ass:draw_start()
+                            elem_ass:rect_cw(-thumbPad * r_h, -thumbPad * r_h, (thumbfast.width + thumbPad) * r_w, (thumbfast.height + thumbPad) * r_h)
+                            elem_ass:draw_stop()
+
+                            mp.commandv("script-message-to", "thumbfast", "thumb",
+                                mp.get_property_number("duration", 0) * (sliderpos / 100),
+                                thumbX,
+                                thumbY
+                            )
+                        end
+                    end
+                else
+                    if thumbfast.width ~= 0 and thumbfast.height ~= 0 then
+                        mp.commandv("script-message-to", "thumbfast", "clear")
+                    end
                 end
             end
 
@@ -2552,6 +2591,15 @@ end
 visibility_mode(user_opts.visibility, true)
 mp.register_script_message('osc-visibility', visibility_mode)
 mp.add_key_binding(nil, 'visibility', function() visibility_mode('cycle') end)
+
+mp.register_script_message("thumbfast-info", function(json)
+    local data = utils.parse_json(json)
+    if type(data) ~= "table" or not data.width or not data.height then
+        msg.error("thumbfast-info: received json didn't produce a table with thumbnail information")
+    else
+        thumbfast = data
+    end
+end)
 
 set_virt_mouse_area(0, 0, 0, 0, 'input')
 set_virt_mouse_area(0, 0, 0, 0, 'window-controls')

--- a/mordenx.lua
+++ b/mordenx.lua
@@ -673,14 +673,16 @@ function render_elements(master_ass)
     -- then we use it instead of the normal title. we calculate it before the
     -- render iterations because the title may be rendered before the slider.
     state.forced_title = nil
-    local se, ae = state.slider_element, elements[state.active_element]
-    if user_opts.chapter_fmt ~= "no" and se and (ae == se or (not ae and mouse_hit(se))) then
-        local dur = mp.get_property_number("duration", 0)
-        if dur > 0 then
-            local possec = get_slider_value(se) * dur / 100 -- of mouse pos
-            local ch = get_chapter(possec)
-            if ch and ch.title and ch.title ~= "" then
-                state.forced_title = string.format(user_opts.chapter_fmt, ch.title)
+    if thumbfast.disabled then
+        local se, ae = state.slider_element, elements[state.active_element]
+        if user_opts.chapter_fmt ~= "no" and se and (ae == se or (not ae and mouse_hit(se))) then
+            local dur = mp.get_property_number("duration", 0)
+            if dur > 0 then
+                local possec = get_slider_value(se) * dur / 100 -- of mouse pos
+                local ch = get_chapter(possec)
+                if ch and ch.title and ch.title ~= "" then
+                    state.forced_title = string.format(user_opts.chapter_fmt, ch.title)
+                end
             end
         end
     end
@@ -819,6 +821,23 @@ function render_elements(master_ass)
                                 thumbX,
                                 thumbY
                             )
+
+                            local se, ae = state.slider_element, elements[state.active_element]
+                            if user_opts.chapter_fmt ~= "no" and se and (ae == se or (not ae and mouse_hit(se))) then
+                                local dur = mp.get_property_number("duration", 0)
+                                if dur > 0 then
+                                    local possec = get_slider_value(se) * dur / 100 -- of mouse pos
+                                    local ch = get_chapter(possec)
+                                    if ch and ch.title and ch.title ~= "" then
+                                        elem_ass:new_event()
+                                        elem_ass:pos((thumbX + thumbfast.width / 2) * r_w, thumbY * r_h - tooltip_font_size)
+                                        elem_ass:an(an)
+                                        elem_ass:append(slider_lo.tooltip_style)
+                                        ass_append_alpha(elem_ass, slider_lo.alpha, 0)
+                                        elem_ass:append(string.format(user_opts.chapter_fmt, ch.title))
+                                    end
+                                end
+                            end
                         end
                     end
                 else


### PR DESCRIPTION
A continuation of #28. Closes #16.

Thumbnails are placed above the video/chapter title to not obstruct anything.  
A border is drawn around the thumbnail.

This should be actually usable now.

Preview:

[thumbfast-modernx.webm](https://user-images.githubusercontent.com/42466980/198843453-3328da28-e303-47fd-8806-92ee387f9738.webm)

