### PR TITLE
Round thumbnail border coordinates

### DIFF
--- a/mordenx.lua
+++ b/mordenx.lua
@@ -809,11 +809,14 @@ function render_elements(master_ass)
                             local thumbX = math.min(osd_w - thumbfast.width - thumbMarginX, math.max(thumbMarginX, tx / r_w - thumbfast.width / 2))
                             local thumbY = (ty - thumbMarginY) / r_h - thumbfast.height
 
+                            thumbX = math.floor(thumbX + 0.5)
+                            thumbY = math.floor(thumbY + 0.5)
+
                             elem_ass:new_event()
                             elem_ass:pos(thumbX * r_w, ty - thumbMarginY - thumbfast.height * r_h)
                             elem_ass:append(osc_styles.Tooltip)
                             elem_ass:draw_start()
-                            elem_ass:rect_cw(-thumbPad * r_h, -thumbPad * r_h, (thumbfast.width + thumbPad) * r_w, (thumbfast.height + thumbPad) * r_h)
+                            elem_ass:rect_cw(-thumbPad * r_w, -thumbPad * r_h, (thumbfast.width + thumbPad) * r_w, (thumbfast.height + thumbPad) * r_h)
                             elem_ass:draw_stop()
 
                             mp.commandv("script-message-to", "thumbfast", "thumb",


### PR DESCRIPTION
Thumbnail border could be misaligned by up to half a pixel in both directions.  
That's because image overlays must be aligned to a pixel, but our ASS border wasn't aligned.

Add `math.floor(thumb_pos + 0.5)` to round to the nearest integer and get an even border on all sides.

Fix a horizontal coordinate mistakenly scaled by the vertical scale factor.