### PR TITLE
osc: fix playpause button becoming unresponsive at EOF

### DIFF
--- a/modernx.lua
+++ b/modernx.lua
@@ -1448,8 +1448,14 @@ function osc_init()
             return (icons.pause)
         end
     end
-    ne.eventresponder['mbtn_left_up'] =
-        function () mp.commandv('cycle', 'pause') end
+    ne.eventresponder['mbtn_left_up'] = function ()
+    if mp.get_property_bool("eof-reached") then
+        mp.command("no-osd seek 0 absolute")
+        mp.set_property("pause", "no")
+    else
+        mp.commandv('cycle', 'pause')
+    end
+end
     --ne.eventresponder['mbtn_right_up'] =
     --    function () mp.commandv('script-binding', 'open-file-dialog') end
 
@@ -2740,3 +2746,4 @@ end)
 
 set_virt_mouse_area(0, 0, 0, 0, 'input')
 set_virt_mouse_area(0, 0, 0, 0, 'window-controls')
+

--- a/modernx.lua
+++ b/modernx.lua
@@ -1449,13 +1449,13 @@ function osc_init()
         end
     end
     ne.eventresponder['mbtn_left_up'] = function ()
-    if mp.get_property_bool("eof-reached") then
-        mp.command("no-osd seek 0 absolute")
-        mp.set_property("pause", "no")
-    else
-        mp.commandv('cycle', 'pause')
+        if mp.get_property_bool("eof-reached") then
+            mp.command("no-osd seek 0 absolute")
+            mp.set_property("pause", "no")
+        else
+            mp.commandv('cycle', 'pause')
+        end
     end
-end
     --ne.eventresponder['mbtn_right_up'] =
     --    function () mp.commandv('script-binding', 'open-file-dialog') end
 
@@ -2746,4 +2746,3 @@ end)
 
 set_virt_mouse_area(0, 0, 0, 0, 'input')
 set_virt_mouse_area(0, 0, 0, 0, 'window-controls')
-


### PR DESCRIPTION
The playpause button in modern.lua fails to restart playback once the video reaches the End of File (EOF) state, even with 'keep-open=yes' enabled. The 'cycle pause' is ineffective when the player is at the absolute end of the stream.

This changes the playpause click handler to:
1. Check for the 'eof-reached' property on clicking.
2. If true perform a 'seek 0' to reset the stream and resume playback.
3. Use 'no-osd' to prevent the native OSD bar from appearing over the custom OSC interface during the reset.
4. Fall back to the default 'cycle pause' behavior if not at EOF.